### PR TITLE
adds tzdata and London TZ envvar to base alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM mhart/alpine-node:10.5
 MAINTAINER Paul Bill <paul.bill@bravissimo.com>
 
 RUN apk add --no-cache bash
+RUN apk add --update tzdata
+ENV TZ Europe/London
 
 CMD ["bash"]


### PR DESCRIPTION
**Observation: serendipitous that a time/dateissue happens to be 2019**

## What does this MR fix?
Sets timezone to be `Europe/London` correctly allowing for `BST/GMT`

## Fixed issues
#2019

## Testing
##### Proof
![image](https://user-images.githubusercontent.com/46821227/67265803-900c8980-f4a6-11e9-96c3-45ca38236086.png)
**devdocker 02 test run on both worker and website containers**

###### Tester
@dave 

###### Additional testing tasks
Alpine base image does not support timezones **out of the box** 

## Is this MR Ready for Review?

* [x] Code complete
* [x] Milestone added to the MR and the issues defined above :point_up:
* [x] Manual testing
* ~~[ ] Tests are passing~~
* ~~[ ] Browser testing~~
* ~~[ ] Additional Rethink queries profiled and results added to the code (in the form of comments)~~

## Technical Assignee
@yodaddyp 
